### PR TITLE
Add a notice about Underglow LEDs and Backlight LEDs.

### DIFF
--- a/Doc/build-en.md
+++ b/Doc/build-en.md
@@ -148,6 +148,7 @@ If the right hand side is the master, you need to build the firmware by specifyi
 To turn on Backlight and Underglow, add the following to rules.mk in the keymap.  
 `BACKLIGHT_ENABLE = yes`  
 `RGBLIGHT_ENABLE = yes  `
+As the default setting, Underglow LEDs turn on, but Backlight LEDs don't turn on. If you want to confirm whether Backlight LEDs work normally or not, press the `BL_TOGG` key (this key is assigned to `Lower + Raise + S` on the default key map).
 
 **If you used firmware 5/5/2019 or earlier in step 5, comment out the following line in rev1 / config.h.**  
 `#define RGBLIGHT_SPLIT`  

--- a/Doc/build.md
+++ b/Doc/build.md
@@ -120,6 +120,7 @@ https://docs.qmk.fm/#/config_options?id=defines-for-handedness
 BacklightとUnderglowを点けるにはkeymap内のrules.mkに以下を追記します。AUDIOについてはサポート外です。  
 `BACKLIGHT_ENABLE = yes`  
 `RGBLIGHT_ENABLE = yes  `
+初期設定値として、Underglow LEDは点灯しますが、Backlight LEDは消灯状態となります。Backlight LEDの点灯を確認する場合は、 `BL_TOGG` キー(defaultキーマップでは `Lower + Raise + S`)を押してください。
 
 **5の工程で2019/5/5以前のファームウェアを使用した場合はrev1/config.h内の以下の行をコメントアウトしてください。**  
 `#define RGBLIGHT_SPLIT`  


### PR DESCRIPTION
組み立てていた際に、Underglow LEDとBacklight LEDの初期点灯状況が異なることに気が付かずに、何らかの不具合によって点灯しなかったのかどうか判断ができませんでした。特にBacklight LEDについて、初期状態では点灯しないこと、点灯させるためには `BL_TOGG` キーを押下することで点灯させることができるということを明記しておいたほうが良いと思いましたので、このPull Requestをお送りさせていただきます。ご確認いただけますと嬉しいです。