### PR TITLE
Fix qmk link

### DIFF
--- a/Doc/build-en.md
+++ b/Doc/build-en.md
@@ -142,7 +142,7 @@ QMK Build Guide
 https://docs.qmk.fm/#/getting_started_build_tools
 
 ErgoDash Firmware
-https://github.com/qmk/qmk_firmware/tree/master/keyboards/ergodash
+https://github.com/qmk/qmk_firmware/tree/master/keyboards/omkbd/ergodash
 
 If the right hand side is the master, you need to build the firmware by specifying `MASTER_RIGHT` in the config.h file in the key map of qmk.  
 To turn on Backlight and Underglow, add the following to rules.mk in the keymap.  

--- a/Doc/build.md
+++ b/Doc/build.md
@@ -110,8 +110,8 @@ https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_jp.md#pro-mic
 ## 12 Firmwareの書き込み
 以下を参考に書き込んでください。または、QMKで検索すると書き込み方がすぐに出てくるはずです。  
 https://docs.qmk.fm/#/getting_started_build_tools  
-ErgoDashのFirmwareは以下にあります。  
-https://github.com/qmk/qmk_firmware/tree/master/keyboards/ergodash
+ErgoDashのFirmwareは以下にあります。
+https://github.com/qmk/qmk_firmware/tree/master/keyboards/omkbd/ergodash
 
 右手側をマスターにした場合はqmkのkeymap内のconfig.hファイルで
 `MASTER_RIGHT`を指定してファームウェアをビルドする必要があります。  

--- a/Doc/ergodash_jp.md
+++ b/Doc/ergodash_jp.md
@@ -56,7 +56,7 @@ PCBとケース以外は基本的に国内サイトで入手可能です。
 ## ファームウェア
 
 QMK Firmwareで動作します。
-[QMK - ErgoDash directory](https://github.com/qmk/qmk_firmware/tree/master/keyboards/ergodash)
+[QMK - ErgoDash directory](https://github.com/qmk/qmk_firmware/tree/master/keyboards/omkbd/ergodash)
 .  
 
 ## 組み立て方

--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,8 @@ NchMOSFET IRLML6344TRPbF × 2
 # Firmware
 
 The ErgoDash uses QMK for its firmware, and the code for it is here:
-[QMK - ErgoDash directory](https://github.com/qmk/qmk_firmware/tree/master/keyboards/ergodash)
-.  
+[QMK - ErgoDash directory](https://github.com/qmk/qmk_firmware/tree/master/keyboards/omkbd/ergodash)
+.
 
 
 # Build Guide


### PR DESCRIPTION
## Abstract
As discussed in https://github.com/omkbd/ErgoDash/issues/47, the URL of qmk_firmware was changed to [it](https://github.com/qmk/qmk_firmware/tree/master/keyboards/omkbd/ergodash). I want to fix the link in some markdowns.

## 概要
https://github.com/omkbd/ErgoDash/issues/47 で議論されている通り、qmk_firmware側のURLが[こちら](https://github.com/qmk/qmk_firmware/tree/master/keyboards/omkbd/ergodash)に変更されているので、ドキュメント内のリンクを修正するPRになります。